### PR TITLE
Removed, what seems to be, misplaced exception throws

### DIFF
--- a/src/main/java/com/graphbuilder/curve/CardinalSpline.java
+++ b/src/main/java/com/graphbuilder/curve/CardinalSpline.java
@@ -133,8 +133,9 @@ public class CardinalSpline extends ParametricCurve {
 			int count_j = gi.count_j();
 
 			for (int i = 0; i < 4; i++) {
-				if (!gi.hasNext())
-					throw new IllegalArgumentException("Group iterator ended early");
+				if (!gi.hasNext()) {
+					return;
+				}
 				sharedData.pt[i] = cp.getPoint(gi.next()).getLocation();
 			}
 

--- a/src/main/java/com/graphbuilder/curve/CatmullRomSpline.java
+++ b/src/main/java/com/graphbuilder/curve/CatmullRomSpline.java
@@ -106,8 +106,9 @@ public class CatmullRomSpline extends ParametricCurve {
 			int count_j = gi.count_j();
 
 			for (int i = 0; i < 4; i++) {
-				if (!gi.hasNext())
-					throw new IllegalArgumentException("Group iterator ended early");
+				if (!gi.hasNext()) {
+					return;
+				}
 				sharedData.pt[i] = cp.getPoint(gi.next()).getLocation();
 			}
 


### PR DESCRIPTION
The LagrangeCurve object also throws this type of exception but it might not be misplaced, because it does not throw it after seemingly valid usage of the appendTo() method (like CardinalSpline and CatmullRomSpline do). So I did not change it. 