### PR TITLE
add AutomaticModuleName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.virtuald</groupId>
   <artifactId>curvesapi</artifactId>
-  <version>1.06</version>
+  <version>1.07</version>
   <name>curvesapi</name>
   <description>Implementation of various mathematical curves that define themselves over a set of control points. The API is written in Java. The curves supported are: Bezier, B-Spline, Cardinal Spline, Catmull-Rom Spline, Lagrange, Natural Cubic Spline, and NURBS.</description>
   <url>https://github.com/virtuald/curvesapi</url>
@@ -15,6 +15,17 @@
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.github.virtuald.curvesapi</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>
@@ -115,7 +126,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This in alternative to https://github.com/virtuald/curvesapi/pull/10

Adding an Automatic-Module-Name to the manifest.mf is enough to allow the lib to be used in [JPM](https://openjdk.java.net/projects/jigsaw/) builds but avoids the need to build with Java 9+.