### PR TITLE
Fix possible stack overflow

### DIFF
--- a/src/main/java/com/graphbuilder/math/ExpressionTree.java
+++ b/src/main/java/com/graphbuilder/math/ExpressionTree.java
@@ -88,7 +88,8 @@ simplified to 16.</li>
 @see com.graphbuilder.math.Expression
 */
 public class ExpressionTree {
-        private static int MAX_LENGTH = 100000;
+        /* The maximum length limit for expression string */
+        private static int MAX_LENGTH = 10000;
 
 	private ExpressionTree() {}
 
@@ -101,6 +102,7 @@ public class ExpressionTree {
 		if (s == null)
 			throw new ExpressionParseException("Expression string cannot be null.", -1);
 
+                // To reduce the chance of stack memory overflow from recursive parsing of long string */
                 if (s.length() > ExpressionTree.MAX_LENGTH)
                         throw new ExpressionParseException("Expression string is too long.", -1);
 

--- a/src/main/java/com/graphbuilder/math/ExpressionTree.java
+++ b/src/main/java/com/graphbuilder/math/ExpressionTree.java
@@ -88,17 +88,21 @@ simplified to 16.</li>
 @see com.graphbuilder.math.Expression
 */
 public class ExpressionTree {
+        private static int MAX_LENGTH = 100000;
 
 	private ExpressionTree() {}
 
 	/**
 	Returns an expression-tree that represents the expression string.  Returns null if the string is empty.
 
-	@throws ExpressionParseException If the string is invalid.
+	@throws ExpressionParseException If the string is invalid or too long.
 	*/
 	public static Expression parse(String s) {
 		if (s == null)
 			throw new ExpressionParseException("Expression string cannot be null.", -1);
+
+                if (s.length() > ExpressionTree.MAX_LENGTH)
+                        throw new ExpressionParseException("Expression string is too long.", -1);
 
 		return build(s, 0);
 	}


### PR DESCRIPTION
This fixes a possible out of stack memory problem in src/main/java/com/graphbuilder/math/ExpressionTree.java

In the public `parse(String)` method of the ExpressionTree class, it takes an expression string to parse it with some private internal parsing methods character by character. Some internal logic will cut off some of the characters from the string and pass the remaining substring recursively to parse it. For example, in [Line 229](https://github.com/virtuald/curvesapi/blob/master/src/main/java/com/graphbuilder/math/ExpressionTree.java#L229) of the ExpressionTree class, it obtains a substring and recursively calls the parse method with the substring and the index. Each recursive call in java will consume some space in the stack memory. If the string is too long with too many triggers of the recursive calls, it will result in Stack memory overflow problems.

This PR reduces the problem by adding an additional length limit as a private class variable. If the provided expression string for the parse method is longer than the maximum length. The method will simply throw an exception.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated curvesapi (https://github.com/google/oss-fuzz/pull/10682). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.
